### PR TITLE
Alternate info/pitch placement using grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,10 +329,43 @@
         
         .book-left {
             padding: 40px;
-            display: flex;
-            flex-direction: column;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            grid-template-rows: auto 1fr 1fr;
+            grid-template-areas:
+                "title title"
+                "info ."
+                ". pitch";
         }
-        
+
+        .layout-info-top-left {
+            grid-template-areas:
+                "title title"
+                "info ."
+                ". pitch";
+        }
+
+        .layout-info-top-right {
+            grid-template-areas:
+                "title title"
+                ". info"
+                "pitch .";
+        }
+
+        .layout-info-bottom-left {
+            grid-template-areas:
+                "title title"
+                ". pitch"
+                "info .";
+        }
+
+        .layout-info-bottom-right {
+            grid-template-areas:
+                "title title"
+                "pitch ."
+                ". info";
+        }
+
         .book-title {
             font-family: 'Playfair Display', serif;
             font-size: 32px;
@@ -340,10 +373,12 @@
             color: #2c3e50;
             margin-bottom: 20px;
             line-height: 1.2;
+            grid-area: title;
         }
-        
+
         .book-info {
             margin-bottom: 30px;
+            grid-area: info;
         }
         
         .info-row {
@@ -372,8 +407,8 @@
             font-size: 12px;
             line-height: 1.6;
             color: #2c3e50;
-            flex: 1;
             box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+            grid-area: pitch;
         }
         
         /* Contours colorés pour le pitch selon le chapitre */
@@ -628,7 +663,7 @@
             </div>
             
             <div class="book-content">
-                <div class="book-left">
+                <div class="book-left layout-info-top-left">
                     <h2 class="book-title">Mirza gets away</h2>
                   
                     
@@ -677,7 +712,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-right">
             <h2 class="book-title">The teapots' day</h2>
             
             <div class="book-info">
@@ -727,7 +762,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">Two little owls</h2>
             
             <div class="book-info">
@@ -777,7 +812,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-right">
             <h2 class="book-title">The Rain</h2>
             
             <div class="book-info">
@@ -829,7 +864,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">When I walk in the desert</h2>
             
             <div class="book-info">
@@ -877,7 +912,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-right">
             <h2 class="book-title">Around a tree</h2>
             
             <div class="book-info">
@@ -931,7 +966,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">When I walk in the desert</h2>
             
             <div class="book-info">
@@ -969,7 +1004,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-right">
             <h2 class="book-title">Zhu and the pearl of water</h2>
             
             <div class="book-info">
@@ -1010,7 +1045,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">The Ear of the forest</h2>
             
             <div class="book-info">
@@ -1049,7 +1084,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-right">
             <h2 class="book-title">The Dragon's shadow</h2>
             
             <div class="book-info">
@@ -1089,7 +1124,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">Little Dust's journey</h2>
             
             <div class="book-info">
@@ -1129,7 +1164,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-right">
             <h2 class="book-title">Tale of the dark night</h2>
             
             <div class="book-info">
@@ -1170,7 +1205,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">The last oak</h2>
             
             <div class="book-info">
@@ -1210,7 +1245,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-right">
             <h2 class="book-title">Traces</h2>
             
             <div class="book-info">
@@ -1252,7 +1287,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">We must turn off the tap!</h2>
             
             <div class="book-info">
@@ -1292,7 +1327,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-right">
             <h2 class="book-title">Nina's autumn</h2>
             
             <div class="book-info">
@@ -1331,7 +1366,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">Titi's Journey</h2>
             
             <div class="book-info">
@@ -1372,7 +1407,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-right">
             <h2 class="book-title">The butterfly in a hurry</h2>
             
             <div class="book-info">
@@ -1410,7 +1445,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">A curious ant</h2>
             
             <div class="book-info">
@@ -1449,7 +1484,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-right">
             <h2 class="book-title">The mother fish</h2>
             
             <div class="book-info">
@@ -1487,7 +1522,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">Lili Pollen</h2>
             
             <div class="book-info">
@@ -1521,7 +1556,7 @@
       <div class="publisher-name">Bluedot</div>
     </div>
     <div class="book-content">
-      <div class="book-left">
+      <div class="book-left layout-info-top-right">
         <h2 class="book-title">Dragons' dream</h2>
         <div class="book-info">
           <div class="info-row"><span class="info-value">Faustine Brunet</span></div>
@@ -1553,7 +1588,7 @@
       <div class="publisher-name">Bluedot</div>
     </div>
     <div class="book-content">
-      <div class="book-left">
+      <div class="book-left layout-info-bottom-left">
         <h2 class="book-title">It's all good with Bob</h2>
         <div class="book-info">
           <div class="info-row"><span class="info-value">Faustine Brunet</span></div>
@@ -1587,7 +1622,7 @@
           <div class="publisher-name">Un chat la nuit</div>
         </div>
         <div class="book-content">
-          <div class="book-left">
+          <div class="book-left layout-info-bottom-right">
             <h2 class="book-title">Comme une orange</h2>
             <div class="book-info">
               <div class="info-row">
@@ -1627,7 +1662,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">The apple and the catch</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1668,7 +1703,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-right">
                 <h2 class="book-title">A Rainbow</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1709,7 +1744,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-left">
                 <h2 class="book-title">Galet</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1750,7 +1785,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-right">
                 <h2 class="book-title">Pierre and Lou</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1791,7 +1826,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">Yune</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1832,7 +1867,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-right">
                 <h2 class="book-title">Rain</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1873,7 +1908,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-left">
                 <h2 class="book-title">The Hungry King</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1913,7 +1948,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-right">
                 <h2 class="book-title">Cosmos Big Band</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1954,7 +1989,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">Only mauve remains</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1994,7 +2029,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-right">
                 <h2 class="book-title">Serena of the Desert</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2034,7 +2069,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-left">
                 <h2 class="book-title">Seasons of the Forest</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2072,7 +2107,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-right">
                 <h2 class="book-title">Wild diary</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2110,7 +2145,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">Second chance</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2148,7 +2183,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-right">
                 <h2 class="book-title">Socotra, men and Dragon Trees</h2>
                 <div class="book-info">
                     <div class="info-row">


### PR DESCRIPTION
## Summary
- convert .book-left from flexbox to CSS grid with template areas
- add four layout modifiers to position book info/pitch in different corners
- update pages to cycle through layout variations

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b174a4c6988329979d30db408e2f72