### PR TITLE
Alternate info/pitch placement using grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,10 +329,43 @@
         
         .book-left {
             padding: 40px;
-            display: flex;
-            flex-direction: column;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            grid-template-rows: auto 1fr 1fr;
+            grid-template-areas:
+                "title title"
+                "info ."
+                ". pitch";
         }
-        
+
+        .layout-info-top-left {
+            grid-template-areas:
+                "title title"
+                "info ."
+                ". pitch";
+        }
+
+        .layout-info-top-right {
+            grid-template-areas:
+                "title title"
+                ". info"
+                "pitch .";
+        }
+
+        .layout-info-bottom-left {
+            grid-template-areas:
+                "title title"
+                ". pitch"
+                "info .";
+        }
+
+        .layout-info-bottom-right {
+            grid-template-areas:
+                "title title"
+                "pitch ."
+                ". info";
+        }
+
         .book-title {
             font-family: 'Playfair Display', serif;
             font-size: 32px;
@@ -340,10 +373,12 @@
             color: #2c3e50;
             margin-bottom: 20px;
             line-height: 1.2;
+            grid-area: title;
         }
-        
+
         .book-info {
             margin-bottom: 30px;
+            grid-area: info;
         }
         
         .info-row {
@@ -372,8 +407,8 @@
             font-size: 12px;
             line-height: 1.6;
             color: #2c3e50;
-            flex: 1;
             box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+            grid-area: pitch;
         }
         
         /* Contours colorés pour le pitch selon le chapitre */
@@ -384,9 +419,14 @@
         
         .book-right {
             padding: 40px;
-            display: flex;
-            flex-direction: column;
-            gap: 20px;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            grid-template-rows: auto 1fr 1fr;
+            grid-template-areas:
+                "title title"
+                ". info"
+                "pitch .";
+            grid-column: 2;
         }
         
         .main-cover {
@@ -628,11 +668,11 @@
             </div>
             
             <div class="book-content">
-                <div class="book-left">
+                <div class="book-left layout-info-top-left">
                     <h2 class="book-title">Mirza gets away</h2>
                   
                     
-                    <div class="book-right">
+                    <div class="book-info">
                         <div class="info-row">
                             <span class="info-value">Marion Sonet</span>
                         </div>
@@ -677,7 +717,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-top-right">
             <h2 class="book-title">The teapots' day</h2>
             
             <div class="book-info">
@@ -727,7 +767,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">Two little owls</h2>
             
             <div class="book-info">
@@ -777,7 +817,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-bottom-right">
             <h2 class="book-title">The Rain</h2>
             
             <div class="book-info">
@@ -829,7 +869,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">When I walk in the desert</h2>
             
             <div class="book-info">
@@ -877,7 +917,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-top-right">
             <h2 class="book-title">Around a tree</h2>
             
             <div class="book-info">
@@ -931,7 +971,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">When I walk in the desert</h2>
             
             <div class="book-info">
@@ -969,7 +1009,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-bottom-right">
             <h2 class="book-title">Zhu and the pearl of water</h2>
             
             <div class="book-info">
@@ -1010,7 +1050,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">The Ear of the forest</h2>
             
             <div class="book-info">
@@ -1049,7 +1089,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-top-right">
             <h2 class="book-title">The Dragon's shadow</h2>
             
             <div class="book-info">
@@ -1089,7 +1129,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">Little Dust's journey</h2>
             
             <div class="book-info">
@@ -1129,7 +1169,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-bottom-right">
             <h2 class="book-title">Tale of the dark night</h2>
             
             <div class="book-info">
@@ -1170,7 +1210,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">The last oak</h2>
             
             <div class="book-info">
@@ -1210,7 +1250,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-top-right">
             <h2 class="book-title">Traces</h2>
             
             <div class="book-info">
@@ -1252,7 +1292,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">We must turn off the tap!</h2>
             
             <div class="book-info">
@@ -1292,7 +1332,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-bottom-right">
             <h2 class="book-title">Nina's autumn</h2>
             
             <div class="book-info">
@@ -1331,7 +1371,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">Titi's Journey</h2>
             
             <div class="book-info">
@@ -1372,7 +1412,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-top-right">
             <h2 class="book-title">The butterfly in a hurry</h2>
             
             <div class="book-info">
@@ -1410,7 +1450,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-bottom-left">
             <h2 class="book-title">A curious ant</h2>
             
             <div class="book-info">
@@ -1449,7 +1489,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-right layout-info-bottom-right">
             <h2 class="book-title">The mother fish</h2>
             
             <div class="book-info">
@@ -1487,7 +1527,7 @@
     </div>
     
     <div class="book-content">
-        <div class="book-left">
+        <div class="book-left layout-info-top-left">
             <h2 class="book-title">Lili Pollen</h2>
             
             <div class="book-info">
@@ -1521,7 +1561,7 @@
       <div class="publisher-name">Bluedot</div>
     </div>
     <div class="book-content">
-      <div class="book-left">
+      <div class="book-right layout-info-top-right">
         <h2 class="book-title">Dragons' dream</h2>
         <div class="book-info">
           <div class="info-row"><span class="info-value">Faustine Brunet</span></div>
@@ -1553,7 +1593,7 @@
       <div class="publisher-name">Bluedot</div>
     </div>
     <div class="book-content">
-      <div class="book-left">
+      <div class="book-left layout-info-bottom-left">
         <h2 class="book-title">It's all good with Bob</h2>
         <div class="book-info">
           <div class="info-row"><span class="info-value">Faustine Brunet</span></div>
@@ -1587,7 +1627,7 @@
           <div class="publisher-name">Un chat la nuit</div>
         </div>
         <div class="book-content">
-          <div class="book-left">
+          <div class="book-right layout-info-bottom-right">
             <h2 class="book-title">Comme une orange</h2>
             <div class="book-info">
               <div class="info-row">
@@ -1627,7 +1667,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">The apple and the catch</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1668,7 +1708,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-right layout-info-top-right">
                 <h2 class="book-title">A Rainbow</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1709,7 +1749,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-left">
                 <h2 class="book-title">Galet</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1750,7 +1790,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-right layout-info-bottom-right">
                 <h2 class="book-title">Pierre and Lou</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1791,7 +1831,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">Yune</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1832,7 +1872,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-right layout-info-top-right">
                 <h2 class="book-title">Rain</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1873,7 +1913,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-left">
                 <h2 class="book-title">The Hungry King</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1913,7 +1953,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-right layout-info-bottom-right">
                 <h2 class="book-title">Cosmos Big Band</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1954,7 +1994,7 @@
             <div class="publisher-name">Panthera</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">Only mauve remains</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -1994,7 +2034,7 @@
             <div class="publisher-name">Comme une orange</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-right layout-info-top-right">
                 <h2 class="book-title">Serena of the Desert</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2034,7 +2074,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-bottom-left">
                 <h2 class="book-title">Seasons of the Forest</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2072,7 +2112,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-right layout-info-bottom-right">
                 <h2 class="book-title">Wild diary</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2110,7 +2150,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-left layout-info-top-left">
                 <h2 class="book-title">Second chance</h2>
                 <div class="book-info">
                     <div class="info-row">
@@ -2148,7 +2188,7 @@
             <div class="publisher-name">Melrakki</div>
         </div>
         <div class="book-content">
-            <div class="book-left">
+            <div class="book-right layout-info-top-right">
                 <h2 class="book-title">Socotra, men and Dragon Trees</h2>
                 <div class="book-info">
                     <div class="info-row">


### PR DESCRIPTION
## Summary
- convert .book-left from flexbox to CSS grid with template areas
- add .book-right grid to occupy right column and alternate page sides
- update pages to cycle between left and right layouts

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b174a4c6988329979d30db408e2f72